### PR TITLE
Update 2016-04-19-elf-planned-landuse.markdown

### DIFF
--- a/models/_posts/2016-04-19-elf-planned-landuse.markdown
+++ b/models/_posts/2016-04-19-elf-planned-landuse.markdown
@@ -1,29 +1,29 @@
 ---
 layout:                 model
-title:                  "Inspire Extensions: ELF Planned Land Use"
+title:                  "Inspire Extensions: Norwegian Planned Land Use"
 date:                   2016-04-19 18:00:02 +0200
 category:               models
-tags:                   [elf, inspire, model, inspireCP40, inspireAD40, inspireHYP40, inspireAU40, inspireGN40, inspirePS40, inspireTN40, inspireLU40, aggregate, associate, inherit]
-modelIdentifier:        elfPLU
-modelName:              "ELF Planned Land Use"
+tags:                   [Inspire, model,inspireLU40, aggregate, associate, inherit]
+modelIdentifier:        Norwegian PLU
+modelName:              "Norwegian Planned Land Use"
 author:                 "Morten Borrebaek"
-modelOrganisation:      "Statkart (Norwegian Mapping Authority)"
+modelOrganisation:      "Kartverket (Norwegian Mapping Authority)"
 modelSummary:           "Planned Land Use extensions UML model"
-modelsReferenced:       [inspireCP40, inspireAD40, inspireHYP40, inspireAU40, inspireGN40, inspirePS40, inspireTN40, inspireLU40]
+modelsReferenced:       [inspireLU40]
 modelReferenceTypes:    [aggregate, associate, inherit]
 modelSchemaLanguage:    "UML, OCL"
-modelSpokenLanguage:    "English, Norwegian"
+modelSpokenLanguage:    "Norwegian, some elements with english aliases."
 modelSchemaTool:        "Enterprise Architect"
-modelMaturity:          "Used in pilots or testbeds"
-modelLatestVersion:     "1.0"
-modelPreviousVersions:  "2-4"
+modelMaturity:          "Under development"
+modelLatestVersion:     "5.0"
+modelPreviousVersions:  "4.5"
 modelNextVersion:       "Long-term resources available"
 modelLicense:           "Open (Unrestricted or attribution-only licenses such as CC-BY, BSD or Apache)"
-modelLink:              http://elfproject.eu/documentation/specification/elf-data-model
+modelLink:              http://sosi.geonorge.no/SVNFAQ/EAP/SOSI_modellregister_JET40.eap (link to model repository with all models)
 modelStatsSizeTypes:    0
 modelStatsSizeProps:    0 
 ---
 
-Ths model was created in the [European Location Framework](http://elfproject.eu/documentation/specification/elf-data-model) (ELF) project. It was created to determine how well national standards align to INSPIRE. Furthermore, the ELF project wanted to make a profile of INSPIRE with some extensions to determine a pragmatic process. ELF specifications were supposed to be built upon INSPIRE, some themes were extended due to existing products from Eurogeographics, mostly due to requirements from Eurostat. For Planned Land Use, a mapping from the national models to INSPIRE was not so difficult, but it required an in depth study with a UML modeller and a Planned Land Use expert. As expected, the national model has more and stronger semantics. In general, the INSPIRE specification was fit for purpose.
+This model was created as part of the revision of Norwegian Planned Land Use model version 4.5, if possibl in alignment with INSPIRE PLU.
 
 The model was stored in a national UML model repository with SVN, with a copy of the INSPIRE and ISO 191xx models in addition to other national models.


### PR DESCRIPTION
---

layout:                 model
title:                  "Inspire Extensions: Norwegian Planned Land Use"
date:                   2016-04-19 18:00:02 +0200
category:               models
tags:                   [Inspire, model,inspireLU40, aggregate, associate, inherit]
modelIdentifier:        Norwegian PLU
modelName:              "Norwegian Planned Land Use"
author:                 "Morten Borrebaek"
modelOrganisation:      "Kartverket (Norwegian Mapping Authority)"
modelSummary:           "Planned Land Use extensions UML model"
modelsReferenced:       [inspireLU40]
modelReferenceTypes:    [aggregate, associate, inherit]
modelSchemaLanguage:    "UML, OCL"
modelSpokenLanguage:    "Norwegian, some elements with english aliases."
modelSchemaTool:        "Enterprise Architect"
modelMaturity:          "Under development"
modelLatestVersion:     "5.0"
modelPreviousVersions:  "4.5"
modelNextVersion:       "Long-term resources available"
modelLicense:           "Open (Unrestricted or attribution-only licenses such as CC-BY, BSD or Apache)"
modelLink:              http://sosi.geonorge.no/SVNFAQ/EAP/SOSI_modellregister_JET40.eap (link to model repository with all models)
modelStatsSizeTypes:    0
## modelStatsSizeProps:    0 

This model was created as part of the revision of Norwegian Planned Land Use model version 4.5, if possibl in alignment with INSPIRE PLU.

The model was stored in a national UML model repository with SVN, with a copy of the INSPIRE and ISO 191xx models in addition to other national models.
